### PR TITLE
Add submitWithAdditionalValues() method in Symfony\Component\BrowserK…

### DIFF
--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -263,6 +263,31 @@ abstract class Client
     }
 
     /**
+     * Submits a form.
+     *
+     * @param Form  $form             A Form instance
+     * @param array $values           An array of form field values
+     * @param array $additionalValues An array of additional field values
+     *
+     * @return Crawler
+     */
+    public function submitWithAdditionalValues(Form $form, array $values = array(), $additionalValues = array())
+    {
+        $form->setValues($values);
+
+        $values = $form->getPhpValues();
+
+        if (!empty($additionalValues)) {
+            $values = array_merge_recursive(
+                $values,
+                $form->convertFieldsToArray($additionalValues)
+            );
+        }
+
+        return $this->request($form->getMethod(), $form->getUri(), $values, $form->getPhpFiles());
+    }
+
+    /**
      * Calls a URI.
      *
      * @param string $method        The request method

--- a/src/Symfony/Component/DomCrawler/Form.php
+++ b/src/Symfony/Component/DomCrawler/Form.php
@@ -130,17 +130,16 @@ class Form extends Link implements \ArrayAccess
     }
 
     /**
-     * Gets the field values as PHP.
-     *
      * This method converts fields with the array notation
      * (like foo[bar] to arrays) like PHP does.
      *
      * @return array An array of field values.
      */
-    public function getPhpValues()
+    public function convertFieldsToArray($fields)
     {
         $values = array();
-        foreach ($this->getValues() as $name => $value) {
+
+        foreach ($fields as $name => $value) {
             $qs = http_build_query(array($name => $value), '', '&');
             if (!empty($qs)) {
                 parse_str($qs, $expandedValue);
@@ -150,6 +149,16 @@ class Form extends Link implements \ArrayAccess
         }
 
         return $values;
+    }
+
+    /**
+     * Gets the field values as PHP.
+     *
+     * @return array An array of field values.
+     */
+    public function getPhpValues()
+    {
+        return $this->convertFieldsToArray($this->getValues());
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | master |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any - WIP |
| License | MIT |
| Doc PR | reference to the documentation PR, if any - WIP |

This PR adds a `submitWithAdditionalValues()` method which you can use in order to submit a form with addtional data.

For example, when you have a `CollectionType` with the `'allow_add' => true,` option, you can't change the values with `$form[FIELD_NAME][…]`.

With the `submitWithAdditionalValues()` method you can add some fields to the request:

```
$client->submitWithAdditionalValues($crawler->filter('input')->form(), array(), array('foo[0]' => 'bar'));
```

Where `array('foo[0]' => 'bar')` is an array which values won't be checked.
