### PR TITLE
remove compatibility layer for doctrine/annotations < 1.6

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1569,15 +1569,6 @@ class FrameworkExtension extends Extension
 
         $loader->load('annotations.php');
 
-        if (!method_exists(AnnotationRegistry::class, 'registerUniqueLoader')) {
-            if (method_exists(AnnotationRegistry::class, 'registerLoader')) {
-                $container->getDefinition('annotations.dummy_registry')
-                    ->setMethodCalls([['registerLoader', ['class_exists']]]);
-            } else {
-                $container->removeDefinition('annotations.dummy_registry');
-            }
-        }
-
         if ('none' === $config['cache']) {
             $container->removeDefinition('annotations.cached_reader');
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Doctrine\Common\Annotations\AnnotationReader;
-use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\Common\Annotations\PsrCachedReader;
 use Doctrine\Common\Annotations\Reader;
 use Symfony\Bundle\FrameworkBundle\CacheWarmer\AnnotationsCacheWarmer;
@@ -25,11 +24,7 @@ return static function (ContainerConfigurator $container) {
         ->set('annotations.reader', AnnotationReader::class)
             ->call('addGlobalIgnoredName', [
                 'required',
-                service('annotations.dummy_registry')->ignoreOnInvalid(), // dummy arg to register class_exists as annotation loader only when required
             ])
-
-        ->set('annotations.dummy_registry', AnnotationRegistry::class)
-            ->call('registerUniqueLoader', ['class_exists'])
 
         ->set('annotations.cached_reader', PsrCachedReader::class)
             ->args([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix `#48792`
| License       | MIT
| Doc PR        | no

While investigating on `#48792`, I observed that removing `$container->removeDefinition('annotations.dummy_registry');` or `service('annotations.dummy_registry')->ignoreOnInvalid(),` fixed the issue.

Let's take the code and add comments:

```php
        // registerUniqueLoader only exists in doctrine/annotations ^1.6
        if (!method_exists(AnnotationRegistry::class, 'registerUniqueLoader')) {
            // registerLoader only exists in doctrine/annotations ^1.0
            if (method_exists(AnnotationRegistry::class, 'registerLoader')) {
                $container->getDefinition('annotations.dummy_registry')
                    ->setMethodCalls([['registerLoader', ['class_exists']]]);
            } else {
                $container->removeDefinition('annotations.dummy_registry');
            }
        }
```

So with `doctrine/annotations` v2, neither `registerUniqueLoader` nor `registerLoader` existed, so the definition `annotations.dummy_registry` was removed.

And it's impossible to install `doctrine/annotations` because of the conflict here: https://github.com/symfony/symfony/blob/6.0/src/Symfony/Bundle/FrameworkBundle/composer.json#L70

So the compatibility layer is not required.

Yet it was decided to not do this change: `https://github.com/symfony/symfony/pull/48725#issuecomment-1360042081`