### PR TITLE
add compatibility layer for doctrine/annotations

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1631,15 +1631,6 @@ class FrameworkExtension extends Extension
 
         $loader->load('annotations.php');
 
-        if (!method_exists(AnnotationRegistry::class, 'registerUniqueLoader')) {
-            if (method_exists(AnnotationRegistry::class, 'registerLoader')) {
-                $container->getDefinition('annotations.dummy_registry')
-                    ->setMethodCalls([['registerLoader', ['class_exists']]]);
-            } else {
-                $container->removeDefinition('annotations.dummy_registry');
-            }
-        }
-
         if ('none' === $config['cache']) {
             $container->removeDefinition('annotations.cached_reader');
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.php
@@ -22,19 +22,13 @@ use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 
 return static function (ContainerConfigurator $container) {
-    // compatibility layer to support doctrine/annotations ^1.0 and ^2.0
-    // registerLoader only exists in doctrine/annotations ^1.0
-    if (method_exists(AnnotationRegistry::class, 'registerLoader')) {
-        // registerUniqueLoader only exists in doctrine/annotations ^1.6
-        if (method_exists(AnnotationRegistry::class, 'registerUniqueLoader')) {
-            $container->services()
-                ->set('annotations.dummy_registry', AnnotationRegistry::class)
-                ->call('registerUniqueLoader', ['class_exists']);
-        } else {
-            $container->services()
-                ->set('annotations.dummy_registry', AnnotationRegistry::class)
-                ->call('registerLoader', ['class_exists']);
-        }
+    // compatibility layer to support doctrine/annotations ^1.13 and ^2.0
+    // registerUniqueLoader only exists in doctrine/annotations ^1.13
+    // (it was added in 1.6 but a conflict forbid versions lower than 1.13.1)
+    if (method_exists(AnnotationRegistry::class, 'registerUniqueLoader')) {
+        $container->services()
+            ->set('annotations.dummy_registry', AnnotationRegistry::class)
+            ->call('registerUniqueLoader', ['class_exists']);
 
         $container->services()
             ->set('annotations.reader', AnnotationReader::class)
@@ -44,7 +38,7 @@ return static function (ContainerConfigurator $container) {
             ])
         ;
     }
-    // for doctrine/annotations v2
+    // with doctrine/annotations v2, there's no need for annotations.dummy_registry
     else {
         $container->services()
             ->set('annotations.reader', AnnotationReader::class)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #48792
| License       | MIT
| Doc PR        | no

The previous code always registered `annotations.dummy_registry` and unregistered it with `doctrine/annotations` v1.

This has the unexpected effect to break the call to `addGlobalIgnoredName` with `doctrine/annotations` v2 : https://github.com/symfony/symfony/issues/48792#issuecomment-1374657943

I propose a novel approach that:
- register `annotations.dummy_registry` only with `doctrine/annotations` v1
- get rid of `registerLoader`, because a conflict block the installation of `doctrine/annotations` without `registerUniqueLoader`: https://github.com/symfony/symfony/blob/5.4/src/Symfony/Bundle/FrameworkBundle/composer.json#L72 and `registerUniqueLoader` is available in 1.13.1 and later releases: https://github.com/doctrine/annotations/blob/1.13.x/lib/Doctrine/Common/Annotations/AnnotationRegistry.php#L124, so a test on `registerUniqueLoader` is enough